### PR TITLE
Move error strings into codecs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
-GO ?= go
 BIN := .tmp/bin
+export PATH := $(BIN):$(PATH)
+export GOBIN := $(abspath $(BIN))
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -20,21 +21,21 @@ all: ## Build, test, and lint (default)
 
 .PHONY: test
 test: build ## Run unit tests
-	$(GO) test -vet=off -race -cover ./...
+	go test -vet=off -race -cover ./...
 
 .PHONY: build
 build: ## Build all packages
-	$(GO) build ./...
+	go build ./...
 
 .PHONY: lint
 lint: $(BIN)/gofmt $(BIN)/staticcheck ## Lint Go
-	test -z "$$($(BIN)/gofmt -s -l . | tee /dev/stderr)"
-	$(GO) vet ./...
-	$(BIN)/staticcheck ./...
+	test -z "$$(gofmt -s -l . | tee /dev/stderr)"
+	go vet ./...
+	staticcheck ./...
 
 .PHONY: lintfix
 lintfix: $(BIN)/gofmt ## Automatically fix some lint errors
-	$(BIN)/gofmt -s -w .
+	gofmt -s -w .
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies
@@ -46,8 +47,8 @@ clean: ## Remove intermediate artifacts
 
 $(BIN)/gofmt:
 	@mkdir -p $(@D)
-	$(GO) build -o $(@) cmd/gofmt
+	go build -o $(@) cmd/gofmt
 
 $(BIN)/staticcheck:
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/binary.go
+++ b/binary.go
@@ -1,6 +1,8 @@
 package connectproto
 
 import (
+	"fmt"
+
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/proto"
 )
@@ -49,7 +51,10 @@ func (b *binaryCodec) Unmarshal(binary []byte, msg any) error {
 	if !ok {
 		return errNotProto(msg)
 	}
-	return b.unmarshal.Unmarshal(binary, pm)
+	if err := b.unmarshal.Unmarshal(binary, pm); err != nil {
+		return fmt.Errorf("unmarshal into %T: %w", pm, err)
+	}
+	return nil
 }
 
 func (b *binaryCodec) Marshal(msg any) ([]byte, error) {
@@ -85,7 +90,10 @@ func newBinaryVTCodec() *vtBinaryCodec {
 
 func (v *vtBinaryCodec) Unmarshal(binary []byte, msg any) error {
 	if vt, ok := msg.(interface{ UnmarshalVT([]byte) error }); ok {
-		return vt.UnmarshalVT(binary)
+		if err := vt.UnmarshalVT(binary); err != nil {
+			return fmt.Errorf("unmarshal into %T: %w", msg, err)
+		}
+		return nil
 	}
 	return v.binaryCodec.Unmarshal(binary, msg)
 }

--- a/error.go
+++ b/error.go
@@ -8,7 +8,7 @@ import (
 
 func errNotProto(msg any) error {
 	if _, ok := msg.(protoiface.MessageV1); ok {
-		return fmt.Errorf("%T uses github.com/golang/protobuf, but connect-go only supports google.golang.org/protobuf: see https://go.dev/blog/protobuf-apiv2", msg)
+		return fmt.Errorf("%T uses github.com/golang/protobuf, but connectproto only supports google.golang.org/protobuf: see https://go.dev/blog/protobuf-apiv2", msg)
 	}
 	return fmt.Errorf("%T doesn't implement proto.Message", msg)
 }

--- a/json.go
+++ b/json.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -36,7 +37,10 @@ func (j *jsonCodec) Unmarshal(binary []byte, msg any) error {
 	if len(binary) == 0 {
 		return errors.New("zero-length payload is not a valid JSON object")
 	}
-	return j.unmarshal.Unmarshal(binary, pm)
+	if err := j.unmarshal.Unmarshal(binary, pm); err != nil {
+		return fmt.Errorf("unmarshal into %T: %w", pm, err)
+	}
+	return nil
 }
 
 func (j *jsonCodec) Marshal(msg any) ([]byte, error) {


### PR DESCRIPTION
Following https://github.com/connectrpc/connect-go/pull/599, make the
errors returned by this package's codecs include the protobuf type name.
